### PR TITLE
REVIKI-591 - Reviki cheatsheet in Jira

### DIFF
--- a/src/main/java/net/hillsdon/reviki/jira/renderer/RevikiHelpAction.java
+++ b/src/main/java/net/hillsdon/reviki/jira/renderer/RevikiHelpAction.java
@@ -1,0 +1,10 @@
+package net.hillsdon.reviki.jira.renderer;
+
+import com.atlassian.jira.web.action.JiraWebActionSupport;
+
+public class RevikiHelpAction extends JiraWebActionSupport {
+  @Override
+  protected String doExecute() throws Exception {
+    return SUCCESS;
+  }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -22,6 +22,11 @@
     <resource type="velocity" name="edit" location="templates/reviki-edit.vm"/>
   </jira-renderer>
 
+  <web-resource key="atlassian-jira-reviki-help" name="Jira Reviki Help">
+    <context>jira.general</context>
+    <resource type="download" name="reviki-help.js" location="js/reviki-help.js"/>
+  </web-resource>
+
   <web-resource key="atlassian-jira-reviki-css" name="Jira Reviki Renderer CSS">
     <context>jira.general</context>
     <resource type="download" name="reviki-style.css" location="style/reviki-style.css"/>
@@ -34,6 +39,14 @@
     <resource type="download" name="reviki-highlight.pack.js" location="js/reviki-highlight.pack.js"/>
     <resource type="download" name="reviki-highlight.js" location="js/reviki-highlight.js"/>
   </web-resource>
+
+  <webwork1 key="reviki-actions" class="java.lang.Object">
+    <actions>
+        <action name="net.hillsdon.reviki.jira.renderer.RevikiHelpAction" alias="RevikiHelpAction">
+            <view name="success">/templates/reviki-help.vm</view>
+        </action>
+    </actions>
+  </webwork1>
 
   <webwork1 key="atlassian-jira-reviki-config"
             name="Jira Reviki Renderer Configuration"

--- a/src/main/resources/js/reviki-help.js
+++ b/src/main/resources/js/reviki-help.js
@@ -1,0 +1,34 @@
+var popupOptions = {
+  toolbar: 'no',
+  location: 'no',
+  directories: 'no',
+  status: 'yes',
+  menubar: 'no',
+  scrollbars: 'yes',
+  resizable: 'yes',
+  width: 380,
+  height: 800
+};
+
+AJS.toInit(function() {
+  var init = function(e, context) {
+    var showHelp = function() {
+      var options = AJS.$.map(popupOptions, function(value, key) {
+        return key + "=" + value;
+      }).join(",");
+      window.open(contextPath + "/RevikiHelpAction.jspa", "reviki_renderer_notation_help", options);
+    }
+
+    AJS.$("a.reviki-preview-button.help-icon").bind("click", function (event) {
+      event.preventDefault();
+      showHelp();
+    });
+  }
+
+  if (JIRA.Events && JIRA.Events.NEW_CONTENT_ADDED) {
+    JIRA.bind(JIRA.Events.NEW_CONTENT_ADDED, init);
+  }
+  else {
+    init();
+  }
+});

--- a/src/main/resources/style/reviki-style.css
+++ b/src/main/resources/style/reviki-style.css
@@ -147,3 +147,39 @@ div.reviki pre.wiki-content {
 .cpp_preproc {
   color: purple;
 }
+
+div#MarkupHelp {
+  background-color: white; color: #333;
+  font-family: Verdana, Arial, Helvetica, sans-serif; line-height: 1.3em;
+}
+div#MarkupHelp table {
+  margin-bottom: 0; border-top: 3px solid #999; border-left: 3px solid #999;
+  border-right: 3px solid #BBB; border-bottom: 3px solid #BBB
+}
+div#MarkupHelp td {
+  font-size: 80%; padding: 0.2em; margin: 0; border: 1px solid #999; border-width: 1px 0 1px 0;
+  vertical-align: top; white-space: nowrap;
+}
+div#MarkupHelp td.arrow {
+  padding-right: 5px; padding: 0 0.75em; color: #999;
+}
+div#MarkupHelp h3 {
+  font-size: 90%; font-weight: bold; margin: 0 0 5px 0; padding: 5px 0 0 0;
+}
+div#MarkupHelp p {
+  font-size: 70%;
+}
+
+#MarkupHelp td {
+  padding: 0;
+}
+
+#MarkupHelp table {
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.reviki-preview-button.help-icon {
+  cursor: pointer;
+  background: url("../../../images/icons/ico_help.png") center no-repeat;
+}

--- a/src/main/resources/templates/reviki-edit.vm
+++ b/src/main/resources/templates/reviki-edit.vm
@@ -33,5 +33,6 @@
       <dd>$!issueKey</dd>
   </dl>
   <a class="fullscreen" href="#" id="${fieldId}-preview_link" title="preview"><span class="aui-icon wiki-renderer-icon"></span></a>
+  <a class="reviki-preview-button help-icon aui-icon" id="reviki-help-button-${fieldId}" title="reviki help"></a>
 </div>
 #end

--- a/src/main/resources/templates/reviki-help.vm
+++ b/src/main/resources/templates/reviki-help.vm
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <!-- $webResourceManager.requireResourcesForContext() should be used to fetch the CSS resource
+         but it doesn't seem to work with webwork1 actions -->
+    <link type="text/css" href="$req.contextPath/download/resources/net.hillsdon.reviki.reviki-plugin:atlassian-jira-reviki-css/reviki-style.css" rel="stylesheet"/>
+  </head>
+  <body>
+    <div id="MarkupHelp">
+      <h3>Reviki Cheatsheet</h3>
+      <table>
+        <tbody>
+        <tr><td>//italics//</td><td class="arrow">&#8594;</td><td><em>italics</em></td></tr>
+        <tr><td>**bold**</td><td class="arrow">&#8594;</td><td><strong>bold</strong></td></tr>
+        <tr><td>--strikethrough--</td><td class="arrow">&#8594;</td><td><del>strikethrough</del></td></tr>
+        <tr><td>* Bullet list<br/>* Second item<br/>** Sub item</td><td class="arrow">&#8594;</td><td>&#8226; Bullet list<br/>&#8226; Second item<br/>..&#8226; Sub item</td></tr>
+        <tr><td># Numbered list<br/># Second item<br/>## Sub item</td><td class="arrow">&#8594;</td><td>1. Numbered list<br/>2. Second item<br/>2.1 Sub item</td></tr>
+        <tr><td>WikiPage, c2:WikiPage</td><td class="arrow">&#8594;</td><td>Internal, inter-wiki links</td></tr>
+        <tr><td>[[AnyLink|named link]]</td><td class="arrow">&#8594;</td><td><a href="">named link</a></td></tr>
+        <tr><td>== Large heading<br/>=== Medium heading<br/>==== Small heading</td><td class="arrow">&#8594;</td><td><span style="font-size: 130%; font-weight: bold;"> Large heading</span><br/><span style="font-size: 115%; font-weight: bold;">Medium heading</span><br/><span style="font-size: 100%; font-weight: bold;">Small heading</span></td></tr>
+        <tr><td>No<br/> linebreak!<br/><br/>Use empty line</td><td class="arrow">&#8594;</td><td>No line break!<br/><br/>Use empty line</td></tr>
+        <tr><td>Forced\\linebreak<br/></td><td class="arrow">&#8594;</td><td>Forced<br/>line break</td></tr>
+        <tr><td>Horizontal line:<br/>----</td><td class="arrow">&#8594;</td><td>Horizontal line: <hr/></td></tr>
+        <tr><td>{{Image.jpg|title}}</td><td class="arrow">&#8594;</td><td>Image with title</td></tr>
+        <tr><td>|=|=table|=header|<br/>|a|table|row|<br/>|b|table|row|</td><td class="arrow">&#8594;</td><td>Table</td></tr>
+        <tr><td>{{{<br/>== [[Nowiki]]:<br/> //**don't** format//<br/>}}}</td><td class="arrow">&#8594;</td><td>== [[Nowiki]]:<br/> //**don't** format//</td></tr>
+        <tr><td>[&lt;html&gt;]<br/>&lt;div&gt;Some HTML&lt;/div&gt;<br/>[&lt;/html&gt;]</td><td class="arrow">&#8594;</td><td><div>Some HTML</div></td></tr>
+      </tbody>
+      </table>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Add a help button for reviki rendered text input element which opens the cheatsheet in a new window.

Ideally the CSS for the cheatsheet would be included using
$webResourceManager.requireResourcesForContext in the velocity template
but this doesn't seem to work for JIRA plugin webwork1 actions.

https://jira.int.corefiling.com/browse/REVIKI-591